### PR TITLE
Improve spacing in the abstract environment.

### DIFF
--- a/{{cookiecutter.project_name}}/main-style.tex
+++ b/{{cookiecutter.project_name}}/main-style.tex
@@ -103,7 +103,7 @@
 \setlength{\absrightindent}{0.5in}
 \setlength{\abstitleskip}{-\absparindent}
 \renewcommand{\abstracttextfont}{\normalfont}
-\abslabeldelim{\:\textemdash}
+\abslabeldelim{\:\textemdash\:}
 \renewcommand{\abstractnamefont}{\normalfont\bfseries\itshape}
 
 % Paragraph indentation
@@ -153,8 +153,6 @@
 
 % Overwrite the title format, specifying font sizes and tightening space between
 % the title text and the author.
-%
-% TODO: Make the spacing between lines a little bigger; things are too tight.
 \makeatletter
 \renewcommand{\maketitle}{\bgroup
    \begin{center}

--- a/{{cookiecutter.project_name}}/main.tex
+++ b/{{cookiecutter.project_name}}/main.tex
@@ -21,7 +21,7 @@
 % You may include a new tex file here using:
 % \input{<file_name>.tex}
 
-\begin{abstract}
+\begin{abstract}%
 If your paper requires an abstract, it should be placed at the top of the first page underneath the title block, preceded by the word \emph{Abstract} in bold italic. An extra 0.5'' should be added to both sides. Not all papers require abstracts; only those that would benefit from a high-level summary of the project or its background.
 \end{abstract}
 


### PR DESCRIPTION
Hey,

This is a super minor change but I figured it was worth including. Previously, there was a space before the emdash in the abstract but not after. So some LaTeX like this:
```latex
\begin{abstract}%
    Here is my abstract.
\end{abstract}
```

Would render to something like:
> _**Abstract**_ &mdash;Here is my abstract.

Which isn't nearly as aesthetically pleasing as the new result with this small change:
> _**Abstract**_ &mdash; Here is my abstract.

Obviously you can add the horizontal spacing to the abstract itself, but that's not as clean as having it built-in, I think!