### PR TITLE
Remove whitespace around `main-style` input

### DIFF
--- a/{{cookiecutter.project_name}}/main.tex
+++ b/{{cookiecutter.project_name}}/main.tex
@@ -1,4 +1,4 @@
-\input{ main-style }
+\input{main-style}
 
 \title{
   {{-cookiecutter.project_title_line_1-}} \\


### PR DESCRIPTION
White space around `main-style` input is being interpreted as a part of the file name, causing a compile time error `LaTeX Error: File 'main-style .tex' not found`
Refer to https://github.com/CuriousLearner/jdf-latex/issues/8